### PR TITLE
Add clear weather favor

### DIFF
--- a/data/community/functions/favor/1s.mcfunction
+++ b/data/community/functions/favor/1s.mcfunction
@@ -45,4 +45,7 @@ execute if score favEasy shroomhearth matches 1.. run function community:favor/e
 # Process "XP Rain" favor
 execute if score favXPRain shroomhearth matches 1.. run function community:favor/xp_rain/process
 # Cleanup lingering chickens
-execute unless score favXPRain shroomhearth matches 1.. as @e[type=minecraft:chicken,tag=xp_rain] at @s run function community:favor/xp_rain/remove_harness 
+execute unless score favXPRain shroomhearth matches 1.. as @e[type=minecraft:chicken,tag=xp_rain] at @s run function community:favor/xp_rain/remove_harness
+
+# Process "Clear Weather" favor
+execute if score favClearWeather shroomhearth matches 1.. run function community:favor/clear_weather/process

--- a/data/community/functions/favor/clear_weather/activate.mcfunction
+++ b/data/community/functions/favor/clear_weather/activate.mcfunction
@@ -1,0 +1,29 @@
+# Clear 1 charm
+clear @s minecraft:ghast_tear{display:{Name:'{"italic":false,"translate":"item.minecraft.charm"}'},CustomModelData:1,Enchantments:[{id:"minecraft:infinity",lvl:1s}],HideFlags:1} 1
+
+# run commands
+weather clear
+gamerule doWeatherCycle false
+
+# update active favors if favor is not already active
+execute if score favClearWeather shroomhearth matches 0 run scoreboard players add favActive shroomhearth 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favClearWeather shroomhearth 3600
+
+# create bossbar
+bossbar add community:favor/clear_weather [{"color":"#7BA4FF","translate":"community.favor.clear_weather"},{"color":"white","text":" - "},{"selector": "@s"}]
+bossbar set community:favor/clear_weather max 3600
+bossbar set community:favor/clear_weather style progress
+bossbar set community:favor/clear_weather value 3600
+bossbar set community:favor/clear_weather visible true
+bossbar set community:favor/clear_weather players @a[scores={showFavorProgress=1}]
+
+# announce activation
+tellraw @a [{"text":"The "},{"color":"#7BA4FF","translate":"community.favor.clear_weather","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.clear_weather.tooltip"}}},{"color":"white","text":" favor was activated by "},{"selector":"@s"}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.8
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/functions/favor/clear_weather/activate.mcfunction
+++ b/data/community/functions/favor/clear_weather/activate.mcfunction
@@ -1,9 +1,9 @@
 # Clear 1 charm
 clear @s minecraft:ghast_tear{display:{Name:'{"italic":false,"translate":"item.minecraft.charm"}'},CustomModelData:1,Enchantments:[{id:"minecraft:infinity",lvl:1s}],HideFlags:1} 1
 
-# run commands
+# clear the weather and stop it from cycling
 weather clear
-gamerule doWeatherCycle true
+gamerule doWeatherCycle false
 
 # update active favors if favor is not already active
 execute if score favClearWeather shroomhearth matches 0 run scoreboard players add favActive shroomhearth 1

--- a/data/community/functions/favor/clear_weather/activate.mcfunction
+++ b/data/community/functions/favor/clear_weather/activate.mcfunction
@@ -3,7 +3,7 @@ clear @s minecraft:ghast_tear{display:{Name:'{"italic":false,"translate":"item.m
 
 # run commands
 weather clear
-gamerule doWeatherCycle false
+gamerule doWeatherCycle true
 
 # update active favors if favor is not already active
 execute if score favClearWeather shroomhearth matches 0 run scoreboard players add favActive shroomhearth 1

--- a/data/community/functions/favor/clear_weather/check.mcfunction
+++ b/data/community/functions/favor/clear_weather/check.mcfunction
@@ -1,0 +1,11 @@
+# This function checks for a player's charm before activating an event
+
+# Check that player has charm
+execute store result score @s hasCharm run clear @s minecraft:ghast_tear{display:{Name:'{"italic":false,"translate":"item.minecraft.charm"}'},CustomModelData:1,Enchantments:[{id:"minecraft:infinity",lvl:1s}],HideFlags:1} 0
+
+# If they don't have charm, send a message
+execute unless predicate community:has_charm run tellraw @s {"translate":"community.missing_charm","hoverEvent":{"action":"show_text","contents":{"translate":"community.missing_charm.tooltip"}}}
+
+# If the player has charm, activate
+execute if predicate community:has_charm if score favClearWeather shroomhearth matches 1.. run function community:favor/clear_weather/extend
+execute if predicate community:has_charm if score favClearWeather shroomhearth matches 0 run function community:favor/clear_weather/activate

--- a/data/community/functions/favor/clear_weather/deactivate.mcfunction
+++ b/data/community/functions/favor/clear_weather/deactivate.mcfunction
@@ -1,5 +1,5 @@
-# update gamerule
-gamerule doWeatherCycle false
+# allow the weather to be chaotic again
+gamerule doWeatherCycle true
 
 # remove bossbar
 bossbar remove community:favor/clear_weather

--- a/data/community/functions/favor/clear_weather/deactivate.mcfunction
+++ b/data/community/functions/favor/clear_weather/deactivate.mcfunction
@@ -5,7 +5,7 @@ gamerule doWeatherCycle false
 bossbar remove community:favor/clear_weather
 
 # announce expiration
-tellraw @a [{"text":"The "},{"color":"#7BA4FF","translate":"community.favor.clear_weather","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.clear_weather"}}},{"color":"white","text":" favor has expired "}]
+tellraw @a [{"text":"The "},{"color":"#7BA4FF","translate":"community.favor.clear_weather","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.clear_weather.tooltip"}}},{"color":"white","text":" favor has expired "}]
 
 # play sound 
 execute as @a at @s run playsound block.beacon.deactivate player @s ~ ~ ~ 1 1.8

--- a/data/community/functions/favor/clear_weather/deactivate.mcfunction
+++ b/data/community/functions/favor/clear_weather/deactivate.mcfunction
@@ -1,0 +1,14 @@
+# update gamerule
+gamerule doWeatherCycle false
+
+# remove bossbar
+bossbar remove community:favor/clear_weather
+
+# announce expiration
+tellraw @a [{"text":"The "},{"color":"#7BA4FF","translate":"community.favor.clear_weather","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.clear_weather"}}},{"color":"white","text":" favor has expired "}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.deactivate player @s ~ ~ ~ 1 1.8
+
+# update active favors 
+scoreboard players remove favActive shroomhearth 1

--- a/data/community/functions/favor/clear_weather/extend.mcfunction
+++ b/data/community/functions/favor/clear_weather/extend.mcfunction
@@ -1,0 +1,20 @@
+# Clear 1 charm
+clear @s minecraft:ghast_tear{display:{Name:'{"italic":false,"translate":"item.minecraft.charm"}'},CustomModelData:1,Enchantments:[{id:"minecraft:infinity",lvl:1s}],HideFlags:1} 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favClearWeather shroomhearth 3600
+
+# update the new max value for bossbar
+execute store result bossbar community:favor/clear_weather max run scoreboard players get favClearWeather shroomhearth
+
+# update the attribution for bossbar
+bossbar set community:favor/clear_weather name [{"color":"#7BA4FF","translate":"community.favor.clear_weather"},{"color":"white","text":" - "},{"selector": "@s"}]
+
+# announce extension
+tellraw @a [{"text":"The "},{"color":"#7BA4FF","translate":"community.favor.clear_weather","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.clear_weather.tooltip"}}},{"color":"white","text":" favor was extended by "},{"selector":"@s"}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.9
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/functions/favor/clear_weather/process.mcfunction
+++ b/data/community/functions/favor/clear_weather/process.mcfunction
@@ -1,0 +1,9 @@
+# tick value
+scoreboard players remove favClearWeather shroomhearth 1
+
+# update bossbar
+execute store result bossbar community:favor/clear_weather value run scoreboard players get favClearWeather shroomhearth
+bossbar set community:favor/clear_weather players @a[scores={showFavorProgress=1}]
+
+# deactivate favor if score reached zero
+execute if score favClearWeather shroomhearth matches ..0 run function community:favor/clear_weather/deactivate


### PR DESCRIPTION
I based this on the Disable Raids favor since it also does not run frequently unlike a potion favor. For the boss bar color, I used #**7BA4FF** as it's one of the [Minecraft sky colors](https://minecraft.fandom.com/wiki/Sky). 