### PR TITLE
WIP: Fix issue where 1 snow layer crafts into 1 block

### DIFF
--- a/data/shroomhearth/recipes/snow.json
+++ b/data/shroomhearth/recipes/snow.json
@@ -7,6 +7,6 @@
     ],
     "result": {
       "item": "minecraft:snow",
-        "count": 8
+      "count": 8
     }
   }

--- a/data/shroomhearth/recipes/snow_block.json
+++ b/data/shroomhearth/recipes/snow_block.json
@@ -1,12 +1,33 @@
 {
     "type": "crafting_shapeless",
     "ingredients": [
-      {
-        "item": "minecraft:snow",
-        "count": 8
-      }
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        },
+        {
+            "item": "minecraft:snow"
+        }
     ],
     "result": {
-      "item": "minecraft:snow_block"
+        "item": "minecraft:snow_block",
+        "count": 1
     }
-  }
+}


### PR DESCRIPTION
`count: 8` does not work for crafting ingredients. This PR uses the correct syntax for having multiple ingredients in a recipe.

**Testing**
1. Reload datapack
2. In a crafting table, place 8 snow in any shape. You should expect to see on the right that 1 snow block can be crafted.
3. Remove one of the snow in the grid. The snow block should disappear.