### PR TITLE
20240104 favors updates

### DIFF
--- a/data/community/functions/favor/1s.mcfunction
+++ b/data/community/functions/favor/1s.mcfunction
@@ -59,3 +59,6 @@ execute if score favDisableCramming shroomhearth matches 1.. run function commun
 
 # Process "No Mob Spawning" favor
 execute if score favDisableSpawning shroomhearth matches 1.. run function community:favor/disable_spawning/process
+
+# Process "No Fall Damage" favor
+execute if score favDisableFallDamage shroomhearth matches 1.. run function community:favor/disable_fall_damage/process

--- a/data/community/functions/favor/disable_fall_damage/activate.mcfunction
+++ b/data/community/functions/favor/disable_fall_damage/activate.mcfunction
@@ -1,0 +1,28 @@
+# Clear 1 charm
+clear @s #community:charm{spore:"charm"} 1
+
+# update gamerule
+gamerule fallDamage false
+
+# update active favors if favor is not already active
+execute if score favDisableFallDamage shroomhearth matches 0 run scoreboard players add favActive shroomhearth 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favDisableFallDamage shroomhearth 3600
+
+# create bossbar
+bossbar add community:favor/disable_fall_damage [{"color":"#FFEFD1","translate":"community.favor.disable_fall_damage"},{"color":"white","text":" - "},{"selector": "@s"}]
+bossbar set community:favor/disable_fall_damage max 3600
+bossbar set community:favor/disable_fall_damage style progress
+bossbar set community:favor/disable_fall_damage value 3600
+bossbar set community:favor/disable_fall_damage visible true
+bossbar set community:favor/disable_fall_damage players @a[scores={showFavorProgress=1}]
+
+# announce activation
+tellraw @a [{"text":"The "},{"color":"#FFEFD1","translate":"community.favor.disable_fall_damage","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.disable_fall_damage.tooltip"}}},{"color":"white","text":" favor was activated by "},{"selector":"@s"}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.8
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/functions/favor/disable_fall_damage/check.mcfunction
+++ b/data/community/functions/favor/disable_fall_damage/check.mcfunction
@@ -1,0 +1,11 @@
+# This function checks for a player's charm before activating an event
+
+# Check that player has charm
+execute store result score @s hasCharm run clear @s #community:charm{spore:"charm"} 0
+
+# If they don't have charm, send a message
+execute unless predicate community:has_charm run tellraw @s {"translate":"community.missing_charm","hoverEvent":{"action":"show_text","contents":{"translate":"community.missing_charm.tooltip"}}}
+
+# If the player has charm, activate
+execute if predicate community:has_charm if score favDisableFallDamage shroomhearth matches 1.. run function community:favor/disable_fall_damage/extend
+execute if predicate community:has_charm if score favDisableFallDamage shroomhearth matches 0 run function community:favor/disable_fall_damage/activate

--- a/data/community/functions/favor/disable_fall_damage/deactivate.mcfunction
+++ b/data/community/functions/favor/disable_fall_damage/deactivate.mcfunction
@@ -1,0 +1,14 @@
+# update gamerule
+gamerule fallDamage true
+
+# remove bossbar
+bossbar remove community:favor/disable_fall_damage
+
+# announce expiration
+tellraw @a [{"text":"The "},{"color":"#FFEFD1","translate":"community.favor.disable_fall_damage","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.disable_fall_damage.tooltip"}}},{"color":"white","text":" favor has expired "}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.deactivate player @s ~ ~ ~ 1 1.8
+
+# update active favors 
+scoreboard players remove favActive shroomhearth 1

--- a/data/community/functions/favor/disable_fall_damage/extend.mcfunction
+++ b/data/community/functions/favor/disable_fall_damage/extend.mcfunction
@@ -1,0 +1,20 @@
+# Clear 1 charm
+clear @s #community:charm{spore:"charm"} 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favDisableFallDamage shroomhearth 3600
+
+# update the new max value for bossbar
+execute store result bossbar community:favor/disable_fall_damage max run scoreboard players get favDisableFallDamage shroomhearth
+
+# update the attribution for bossbar
+bossbar set community:favor/disable_fall_damage name [{"color":"#FFEFD1","translate":"community.favor.disable_fall_damage"},{"color":"white","text":" - "},{"selector": "@s"}]
+
+# announce extension
+tellraw @a [{"text":"The "},{"color":"#FFEFD1","translate":"community.favor.disable_fall_damage","hoverEvent":{"action":"show_text","contents":{"translate":"community.favor.disable_fall_damage.tooltip"}}},{"color":"white","text":" favor was extended by "},{"selector":"@s"}]
+
+# play sound 
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.9
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/functions/favor/disable_fall_damage/process.mcfunction
+++ b/data/community/functions/favor/disable_fall_damage/process.mcfunction
@@ -1,0 +1,9 @@
+# tick value
+scoreboard players remove favDisableFallDamage shroomhearth 1
+
+# update bossbar
+execute store result bossbar community:favor/disable_fall_damage value run scoreboard players get favDisableFallDamage shroomhearth
+bossbar set community:favor/disable_fall_damage players @a[scores={showFavorProgress=1}]
+
+# deactivate favor if score reached zero
+execute if score favDisableFallDamage shroomhearth matches ..0 run function community:favor/disable_fall_damage/deactivate

--- a/data/community/functions/favor/regeneration/process.mcfunction
+++ b/data/community/functions/favor/regeneration/process.mcfunction
@@ -2,7 +2,7 @@
 scoreboard players remove favRegeneration shroomhearth 1
 
 # check regeneration duration
-execute as @a store result score @s regenerationDuration run data get entity @s ActiveEffects[{Id:10}].Duration
+execute as @a store result score @s regenerationDuration run data get entity @s active_effects[{id:"minecraft:regeneration"}].duration
 
 # apply effect if regen is less than 1 second
 execute as @a if score @s regenerationDuration matches ..20 run effect give @s minecraft:regeneration 11 0 true

--- a/data/community/functions/objectives/remove.mcfunction
+++ b/data/community/functions/objectives/remove.mcfunction
@@ -59,3 +59,4 @@ scoreboard players reset favStopDaylight shroomhearth
 scoreboard players reset favHorsepower shroomhearth
 scoreboard players reset favDisableCramming shroomhearth
 scoreboard players reset favDisableSpawning shroomhearth
+scoreboard players reset favDisableFallDamage shroomhearth

--- a/data/ender_dragon/functions/powers/pillar/build_pillar.mcfunction
+++ b/data/ender_dragon/functions/powers/pillar/build_pillar.mcfunction
@@ -8,7 +8,7 @@ kill @s
 fill ~ ~ ~ ~ ~3 ~ minecraft:crying_obsidian
 
 # create pillar marker
-summon minecraft:armor_stand ~ ~ ~ {Marker:true,Invisible:true,Tags:["pillar_marker"],Passengers:[{id:"minecraft:slime",Size:11,Tags:["pillar_gravity"],NoAI:true,NoGravity:true,Invulnerable:true,Silent:true,DeathTime:19,DeathLootTable:"minecraft:empty",ActiveEffects:[{Id:14,Duration:1000000,ShowParticles:false}]}]}
+summon minecraft:armor_stand ~ ~ ~ {Marker:true,Invisible:true,Tags:["pillar_marker"],Passengers:[{id:"minecraft:slime",Size:11,Tags:["pillar_gravity"],NoAI:true,NoGravity:true,Invulnerable:true,Silent:true,DeathTime:19,DeathLootTable:"minecraft:empty",active_effects:[{id:"minecraft:invisibility",duration:1000000,show_particles:false}]}]}
 
 # play particles on pillars
 particle minecraft:dragon_breath ~ ~2 ~ 0.5 2 0.5 0.05 20 force


### PR DESCRIPTION
- Added a "No Fall Damage" timed favor.
- Fixed a bug preventing the Regeneration favor from restoring health properly.
- Fixed a bug causing the slime "forcefields" around ender dragon pillars to be visible.