### PR TITLE
fix: players can sleep in during thunderstorms

### DIFF
--- a/data/sleeping/function/player_sleeping.mcfunction
+++ b/data/sleeping/function/player_sleeping.mcfunction
@@ -3,3 +3,9 @@ execute at @s if entity @p[tag=sleeping,distance=1..] run advancement grant @s o
 
 # make night pass faster for sleeping players
 time add 10
+
+# get and store time of day when it's thundering
+execute if predicate sleeping:is_thundering store result score shroomhearth dayTime run time query daytime
+
+# when it is daytime and thundering, then force clear the weather so that the player can be woken up
+execute if predicate sleeping:is_thundering if score shroomhearth dayTime matches 12010..23992 run weather clear

--- a/data/sleeping/function/player_sleeping.mcfunction
+++ b/data/sleeping/function/player_sleeping.mcfunction
@@ -8,4 +8,4 @@ time add 10
 execute if predicate sleeping:is_thundering store result score shroomhearth dayTime run time query daytime
 
 # when it is daytime and thundering, then force clear the weather so that the player can be woken up
-execute if predicate sleeping:is_thundering if score shroomhearth dayTime matches 12010..23992 run weather clear
+execute if predicate sleeping:is_thundering unless score shroomhearth dayTime matches 12010..23992 run weather clear

--- a/data/sleeping/function/player_wake_up.mcfunction
+++ b/data/sleeping/function/player_wake_up.mcfunction
@@ -7,7 +7,3 @@ tag @s remove sleeping
 # query time and reset weather if player woke up during day (likely a full sleep)
 execute store result score shroomhearth dayTime run time query daytime
 execute unless score shroomhearth dayTime matches 12010..23992 run weather clear
-
-# use a predicate to detect if it's thundering
-# @see interactive predicate generator https://misode.github.io/predicate/
-execute if predicate sleeping:is_thundering run weather clear

--- a/data/sleeping/function/player_wake_up.mcfunction
+++ b/data/sleeping/function/player_wake_up.mcfunction
@@ -7,3 +7,7 @@ tag @s remove sleeping
 # query time and reset weather if player woke up during day (likely a full sleep)
 execute store result score shroomhearth dayTime run time query daytime
 execute unless score shroomhearth dayTime matches 12010..23992 run weather clear
+
+# use a predicate to detect if it's thundering
+# @see interactive predicate generator https://misode.github.io/predicate/
+execute if predicate sleeping:is_thundering run weather clear

--- a/data/sleeping/predicate/is_thundering.json
+++ b/data/sleeping/predicate/is_thundering.json
@@ -1,0 +1,4 @@
+{
+    "condition": "weather_check",
+    "thundering": true
+}

--- a/data/sleeping/predicate/is_thundering.json
+++ b/data/sleeping/predicate/is_thundering.json
@@ -1,4 +1,4 @@
 {
-    "condition": "weather_check",
+    "condition": "minecraft:weather_check",
     "thundering": true
 }


### PR DESCRIPTION
caveat: I've only tested this via the inline method `execute if {condition:"minecraft:weather_check",thundering:1b} run weather clear`