### PR TITLE
Add Disable PvP favor using new gamerule

### DIFF
--- a/data/community/function/favor/1s.mcfunction
+++ b/data/community/function/favor/1s.mcfunction
@@ -63,5 +63,8 @@ execute if score favDisableSpawning shroomhearth matches 1.. run function commun
 # Process "No Fall Damage" favor
 execute if score favDisableFallDamage shroomhearth matches 1.. run function community:favor/disable_fall_damage/process
 
+# Process "Disable PvP" favor
+execute if score favDisablePvp shroomhearth matches 1.. run function community:favor/disable_pvp/process
+
 # Process "Locator Bar" favor
 execute if score favLocatorBar shroomhearth matches 1.. run function community:favor/locator_bar/process

--- a/data/community/function/favor/disable_pvp/activate.mcfunction
+++ b/data/community/function/favor/disable_pvp/activate.mcfunction
@@ -1,0 +1,28 @@
+# Clear 1 charm
+clear @s #community:charm[custom_data={spore:"charm"}] 1
+
+# update gamerule
+gamerule pvp false
+
+# update active favors if favor is not already active
+execute if score favDisablePvp shroomhearth matches 0 run scoreboard players add favActive shroomhearth 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favDisablePvp shroomhearth 3600
+
+# create bossbar
+bossbar add community:favor/disable_pvp [{"color":"#E15554","translate":"community.favor.disable_pvp"},{"color":"white","text":" - "},{"selector": "@s"}]
+bossbar set community:favor/disable_pvp max 3600
+bossbar set community:favor/disable_pvp style progress
+bossbar set community:favor/disable_pvp value 3600
+bossbar set community:favor/disable_pvp visible true
+bossbar set community:favor/disable_pvp players @a[scores={showFavorProgress=1}]
+
+# announce activation
+tellraw @a [{"text":"The "},{"color":"#E15554","translate":"community.favor.disable_pvp","hover_event":{"action":"show_text","value":{"translate":"community.favor.disable_pvp.tooltip"}}},{"color":"white","text":" favor was activated by "},{"selector":"@s"}]
+
+# play sound
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.8
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/function/favor/disable_pvp/check.mcfunction
+++ b/data/community/function/favor/disable_pvp/check.mcfunction
@@ -1,0 +1,11 @@
+# This function checks for a player's charm before activating an event
+
+# Check that player has charm
+execute store result score @s hasCharm run clear @s #community:charm[custom_data={spore:"charm"}] 0
+
+# If they don't have charm, send a message
+execute unless predicate community:has_charm run tellraw @s {"translate":"community.missing_charm","hover_event":{"action":"show_text","value":{"translate":"community.missing_charm.tooltip"}}}
+
+# If the player has charm, activate
+execute if predicate community:has_charm if score favDisablePvp shroomhearth matches 1.. run function community:favor/disable_pvp/extend
+execute if predicate community:has_charm if score favDisablePvp shroomhearth matches 0 run function community:favor/disable_pvp/activate

--- a/data/community/function/favor/disable_pvp/deactivate.mcfunction
+++ b/data/community/function/favor/disable_pvp/deactivate.mcfunction
@@ -1,0 +1,14 @@
+# update gamerule
+gamerule pvp true
+
+# remove bossbar
+bossbar remove community:favor/disable_pvp
+
+# announce expiration
+tellraw @a [{"text":"The "},{"color":"#E15554","translate":"community.favor.disable_pvp","hover_event":{"action":"show_text","value":{"translate":"community.favor.disable_pvp.tooltip"}}},{"color":"white","text":" favor has expired "}]
+
+# play sound
+execute as @a at @s run playsound block.beacon.deactivate player @s ~ ~ ~ 1 1.8
+
+# update active favors
+scoreboard players remove favActive shroomhearth 1

--- a/data/community/function/favor/disable_pvp/extend.mcfunction
+++ b/data/community/function/favor/disable_pvp/extend.mcfunction
@@ -1,0 +1,20 @@
+# Clear 1 charm
+clear @s #community:charm[custom_data={spore:"charm"}] 1
+
+# add value - 3600 seconds in an hour
+scoreboard players add favDisablePvp shroomhearth 3600
+
+# update the new max value for bossbar
+execute store result bossbar community:favor/disable_pvp max run scoreboard players get favDisablePvp shroomhearth
+
+# update the attribution for bossbar
+bossbar set community:favor/disable_pvp name [{"color":"#E15554","translate":"community.favor.disable_pvp"},{"color":"white","text":" - "},{"selector": "@s"}]
+
+# announce extension
+tellraw @a [{"text":"The "},{"color":"#E15554","translate":"community.favor.disable_pvp","hover_event":{"action":"show_text","value":{"translate":"community.favor.disable_pvp.tooltip"}}},{"color":"white","text":" favor was extended by "},{"selector":"@s"}]
+
+# play sound
+execute as @a at @s run playsound block.beacon.power_select player @s ~ ~ ~ 1 1.9
+
+# grant advancement
+advancement grant @s only community:community_contributor

--- a/data/community/function/favor/disable_pvp/process.mcfunction
+++ b/data/community/function/favor/disable_pvp/process.mcfunction
@@ -1,0 +1,9 @@
+# tick value
+scoreboard players remove favDisablePvp shroomhearth 1
+
+# update bossbar
+execute store result bossbar community:favor/disable_pvp value run scoreboard players get favDisablePvp shroomhearth
+bossbar set community:favor/disable_pvp players @a[scores={showFavorProgress=1}]
+
+# deactivate favor if score reached zero
+execute if score favDisablePvp shroomhearth matches ..0 run function community:favor/disable_pvp/deactivate

--- a/data/community/function/objectives/add.mcfunction
+++ b/data/community/function/objectives/add.mcfunction
@@ -66,4 +66,5 @@ scoreboard players set favHorsepower shroomhearth 0
 scoreboard players set favDisableCramming shroomhearth 0
 scoreboard players set favDisableSpawning shroomhearth 0
 scoreboard players set favDisableFallDamage shroomhearth 0
+scoreboard players set favDisablePvp shroomhearth 0
 scoreboard players set favLocatorBar shroomhearth 0

--- a/data/community/function/objectives/remove.mcfunction
+++ b/data/community/function/objectives/remove.mcfunction
@@ -63,4 +63,5 @@ scoreboard players reset favHorsepower shroomhearth
 scoreboard players reset favDisableCramming shroomhearth
 scoreboard players reset favDisableSpawning shroomhearth
 scoreboard players reset favDisableFallDamage shroomhearth
+scoreboard players reset favDisablePvp shroomhearth
 scoreboard players reset favLocatorBar shroomhearth


### PR DESCRIPTION
## Summary
- add a Disable PvP favor that clears a charm, toggles the new pvp gamerule, and manages its bossbar lifecycle
- register the favor in the shared scoreboard setup and processing loop so it counts toward active favors

## Testing
- not run (datapack changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ca105d98bc832b94342b6804545df1