### PR TITLE
Ensure copper golem painted egg appears in random loot

### DIFF
--- a/data/easter/loot_table/random_painted_egg.json
+++ b/data/easter/loot_table/random_painted_egg.json
@@ -61,6 +61,10 @@
                 },
                 {
                     "type": "minecraft:loot_table",
+                    "value": "easter:copper_golem_painted_egg"
+                },
+                {
+                    "type": "minecraft:loot_table",
                     "value": "easter:cow_painted_egg"
                 },
                 {


### PR DESCRIPTION
## Summary
- add the copper golem painted egg loot table to the random painted egg pool so every egg is represented

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e449a400832bb3cd0fc95bfdf862